### PR TITLE
Fix condition when using abstract uri and improve Windows compatibility.

### DIFF
--- a/Bin/Bhoa.php
+++ b/Bin/Bhoa.php
@@ -365,7 +365,7 @@ class Bhoa extends \Hoa\Console\Dispatcher\Kit {
                         $request->getHeadersFormatted(),
                         array(
                             'REQUEST_METHOD'  => 'GET',
-                            'REQUEST_URI'     => DS . $uri,
+                            'REQUEST_URI'     => $uri,
                             'REQUEST_TIME'    => time(),
                             'SCRIPT_FILENAME' => $script_filename,
                             'SCRIPT_NAME'     => $script_name
@@ -388,7 +388,7 @@ class Bhoa extends \Hoa\Console\Dispatcher\Kit {
                         $request->getHeadersFormatted(),
                         array(
                             'REQUEST_METHOD'  => 'POST',
-                            'REQUEST_URI'     => DS . $uri,
+                            'REQUEST_URI'     => $uri,
                             'REQUEST_TIME'    => time(),
                             'SCRIPT_FILENAME' => $script_filename,
                             'SCRIPT_NAME'     => $script_name,


### PR DESCRIPTION
HI,

When we use a custom router [like here](http://hoa-project.net/En/Literature/Learn/Routerdispatcher.html) with BHoa, we can request uri which `resolve` can't find.
So when BHoa check if the target exists, the return is false (line 232) but just after (line 329) BHoa do a `pathinfo` on this target (who it's not a file) and check if the extension is `php`.

But like we can see on [php.net](http://www.php.net/manual/en/function.pathinfo.php): _If the path does not have an extension, no extension element will be returned_. 

So Hoa throw a error and we finish with a fatal error uncaught exception.

I don't understand how the [example](http://hoa-project.net/En/Literature/Learn/Routerdispatcher.html) can work without that... or I've miss something.
